### PR TITLE
build(proto): move build script to separate pkg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,13 +59,9 @@ name = "archway-proto"
 version = "0.1.0"
 dependencies = [
  "cosmos-sdk-proto",
- "error-chain",
- "glob",
  "prost",
  "prost-types",
- "regex",
  "tonic",
- "tonic-build",
 ]
 
 [[package]]
@@ -1118,6 +1114,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "proto-build"
+version = "0.1.0"
+dependencies = [
+ "error-chain",
+ "glob",
+ "regex",
+ "tonic-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 [workspace]
-members = ["packages/*", "contracts/*"]
+members = [
+  "packages/*",
+  "contracts/*",
+  "proto-build"
+]
 resolver = "2"
 
 [workspace.package]

--- a/packages/proto/Cargo.toml
+++ b/packages/proto/Cargo.toml
@@ -30,12 +30,6 @@ tonic = { version = "0.9.2", optional = true, default-features = false, features
 # cosmos-sdk-proto@0.18.0 is the latest version for the cosmos-sdk 0.45.x protos
 cosmos-sdk-proto = { version = "0.18.0", default-features = false }
 
-[build-dependencies]
-error-chain = "0.12.4"
-glob = "0.3.1"
-regex = "1.9.3"
-tonic-build = "0.9.2"
-
 [features]
 default = ["grpc-transport"]
 grpc-transport = ["grpc", "tonic/transport", "cosmos-sdk-proto/grpc-transport"]

--- a/proto-build/Cargo.toml
+++ b/proto-build/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "proto-build"
+version = "0.1.0"
+edition = "2021"
+description = "Build script for archway-proto"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish = false
+
+[dependencies]
+error-chain = "0.12.4"
+glob = "0.3.1"
+regex = "1.9.3"
+tonic-build = "0.9.2"


### PR DESCRIPTION
It was impossible to publish the `archway-proto` crate because it depends on the `archway-network` submodule, which is unavailable during the isolated build process.

Following the same approach as `cosmos-rust` and other projects, moving the proto compilation from the `build.rs` script in the package to a standalone binary was necessary.