### PR TITLE
fix(proto): added CosmWasm compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,6 @@ dependencies = [
  "serde",
  "subtle-encoding",
  "tendermint-proto",
- "tonic",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,6 +934,7 @@ dependencies = [
  "serde",
  "subtle-encoding",
  "tendermint-proto",
+ "tonic",
 ]
 
 [[package]]

--- a/packages/proto/Cargo.toml
+++ b/packages/proto/Cargo.toml
@@ -27,8 +27,12 @@ tonic = { version = "0.12.3", optional = true, default-features = false, feature
   "codegen",
   "prost",
 ] }
-cosmos-sdk-proto = { version = "0.26.0", default-features = false, features = ["serde"] }
-ibc-proto = { version = "0.51.0", default-features = false, features = ["serde"] }
+cosmos-sdk-proto = { version = "0.26.0", default-features = false, features = [
+  "serde",
+] }
+ibc-proto = { version = "0.51.0", default-features = false, features = [
+  "serde",
+] }
 
 [dev-dependencies]
 serde_test = "1.0"
@@ -38,9 +42,14 @@ tokio = { version = "1.41.0", features = ["full"] }
 
 [features]
 default = ["grpc-transport"]
-grpc-transport = ["grpc", "tonic/transport", "cosmos-sdk-proto/grpc-transport"]
-grpc = ["tonic", "cosmos-sdk-proto/grpc"]
-cosmwasm = ["cosmos-sdk-proto/cosmwasm"]
+std = ["prost/std", "cosmos-sdk-proto/std", "ibc-proto/std"]
+grpc = ["std", "tonic", "cosmos-sdk-proto/grpc", "ibc-proto/client"]
+grpc-transport = [
+  "grpc",
+  "tonic/transport",
+  "cosmos-sdk-proto/grpc-transport",
+  "ibc-proto/transport",
+]
 proto-descriptor = ["ibc-proto/proto-descriptor"]
 # Replaces all structs that use Any with a generic type
 abstract-any = []

--- a/packages/proto/Cargo.toml
+++ b/packages/proto/Cargo.toml
@@ -28,7 +28,7 @@ tonic = { version = "0.12.3", optional = true, default-features = false, feature
   "prost",
 ] }
 cosmos-sdk-proto = { version = "0.26.0", features = ["serde"] }
-ibc-proto = { version = "0.51.0", features = ["serde"] }
+ibc-proto = { version = "0.51.0", default-features = false, features = ["serde"] }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/packages/proto/Cargo.toml
+++ b/packages/proto/Cargo.toml
@@ -27,7 +27,7 @@ tonic = { version = "0.12.3", optional = true, default-features = false, feature
   "codegen",
   "prost",
 ] }
-cosmos-sdk-proto = { version = "0.26.0", features = ["serde"] }
+cosmos-sdk-proto = { version = "0.26.0", default-features = false, features = ["serde"] }
 ibc-proto = { version = "0.51.0", default-features = false, features = ["serde"] }
 
 [dev-dependencies]

--- a/packages/proto/examples/grpc-client.rs
+++ b/packages/proto/examples/grpc-client.rs
@@ -1,11 +1,12 @@
 use anyhow::Result;
 use archway_proto::archway;
-use tonic::transport::Channel;
+use tonic::transport::{Channel, ClientTlsConfig};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let addr = "https://grpc.mainnet.archway.io:443";
-    let channel = Channel::from_static(addr).connect().await?;
+    let tls_config = ClientTlsConfig::new().with_native_roots();
+    let channel = Channel::from_static(addr).tls_config(tls_config)?.connect().await?;
 
     let mut client = archway::rewards::v1::query_client::QueryClient::new(channel);
 

--- a/packages/proto/examples/grpc-client.rs
+++ b/packages/proto/examples/grpc-client.rs
@@ -6,7 +6,10 @@ use tonic::transport::{Channel, ClientTlsConfig};
 async fn main() -> Result<()> {
     let addr = "https://grpc.mainnet.archway.io:443";
     let tls_config = ClientTlsConfig::new().with_native_roots();
-    let channel = Channel::from_static(addr).tls_config(tls_config)?.connect().await?;
+    let channel = Channel::from_static(addr)
+        .tls_config(tls_config)?
+        .connect()
+        .await?;
 
     let mut client = archway::rewards::v1::query_client::QueryClient::new(channel);
 

--- a/packages/proto/src/lib.rs
+++ b/packages/proto/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(rustdoc::bare_urls, clippy::derive_partial_eq_without_eq)]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "abstract-any")]
 pub mod any;


### PR DESCRIPTION
Using the newest version of the repository causes building errors with cosmwasm smart contracts, this was found to be related to `ibc-proto` and `cosmos-sdk-proto` using the `transport` feature by default.

Resolves: #41 